### PR TITLE
Fix multiplication token and join parsing

### DIFF
--- a/ParserLib/Lexer.cs
+++ b/ParserLib/Lexer.cs
@@ -114,6 +114,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.Provider.SQLit
                 ["LEFT"] = SqlTokenType.LEFT,
                 ["RIGHT"] = SqlTokenType.RIGHT,
                 ["FULL"] = SqlTokenType.FULL,
+                ["CROSS"] = SqlTokenType.CROSS,
                 ["OUTER"] = SqlTokenType.OUTER,
                 ["ON"] = SqlTokenType.ON,
                 ["WITH"] = SqlTokenType.WITH,

--- a/ParserLib/SqlParser.cs
+++ b/ParserLib/SqlParser.cs
@@ -381,9 +381,14 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.Provider.SQLit
         {
             var expr = this.ParseUnary();
 
-            while (this.Match(SqlTokenType.STAR, SqlTokenType.DIVIDE, SqlTokenType.MODULO))
+            while (this.Match(SqlTokenType.STAR, SqlTokenType.MULTIPLY, SqlTokenType.DIVIDE, SqlTokenType.MODULO))
             {
                 var op = this.Previous().Type;
+                if (op == SqlTokenType.STAR)
+                {
+                    op = SqlTokenType.MULTIPLY;
+                }
+
                 var right = this.ParseUnary();
                 expr = new BinaryExpression { Left = expr, Operator = op, Right = right };
             }

--- a/ParserTests/ParserTests.cs
+++ b/ParserTests/ParserTests.cs
@@ -407,7 +407,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.UnitTest.Parse
                 "Expression should be BinaryExpression for multiplication");
 
             var binaryExpr = (BinaryExpression)expr;
-            Assert.AreEqual(SqlTokenType.STAR, binaryExpr.Operator);
+            Assert.AreEqual(SqlTokenType.MULTIPLY, binaryExpr.Operator);
             Assert.AreEqual("price", ((ColumnExpression)binaryExpr.Left).ColumnName);
             Assert.AreEqual(2.0, ((LiteralExpression)binaryExpr.Right).Value);
         }
@@ -448,7 +448,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.UnitTest.Parse
             // Left side of addition should be multiplication: price * quantity
             var multiplyExpr = leftExpr.Left as BinaryExpression;
             Assert.IsNotNull(multiplyExpr);
-            Assert.AreEqual(SqlTokenType.STAR, multiplyExpr.Operator);
+            Assert.AreEqual(SqlTokenType.MULTIPLY, multiplyExpr.Operator);
             Assert.AreEqual("price", ((ColumnExpression)multiplyExpr.Left).ColumnName);
             Assert.AreEqual("quantity", ((ColumnExpression)multiplyExpr.Right).ColumnName);
 
@@ -472,7 +472,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.UnitTest.Parse
             // First expression with explicit alias
             var expr1 = ast.SelectList[0].Expression as BinaryExpression;
             Assert.IsNotNull(expr1);
-            Assert.AreEqual(SqlTokenType.STAR, expr1.Operator);
+            Assert.AreEqual(SqlTokenType.MULTIPLY, expr1.Operator);
             Assert.AreEqual("total_price", ast.SelectList[0].Alias);
 
             // Second expression with implicit alias
@@ -499,7 +499,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.UnitTest.Parse
             // First: (price + tax) * quantity
             var expr1 = ast.SelectList[0].Expression as BinaryExpression;
             Assert.IsNotNull(expr1);
-            Assert.AreEqual(SqlTokenType.STAR, expr1.Operator);
+            Assert.AreEqual(SqlTokenType.MULTIPLY, expr1.Operator);
             Assert.AreEqual("total_with_tax", ast.SelectList[0].Alias);
 
             // Verify the grouped expression
@@ -510,7 +510,7 @@ namespace Microsoft.AzureStack.Services.Update.Common.Persistence.UnitTest.Parse
             // Second: price * 0.9
             var expr2 = ast.SelectList[1].Expression as BinaryExpression;
             Assert.IsNotNull(expr2);
-            Assert.AreEqual(SqlTokenType.STAR, expr2.Operator);
+            Assert.AreEqual(SqlTokenType.MULTIPLY, expr2.Operator);
             Assert.AreEqual(0.9, ((LiteralExpression)expr2.Right).Value);
 
             // Third: CASE expression


### PR DESCRIPTION
## Summary
- ensure lexer recognizes CROSS join
- treat `*` as MULTIPLY in expression parsing
- update tests for new multiplication token

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68945e2bee7c832d80e8b98538bae3c2